### PR TITLE
Adds OpenTelemetry via Crucible Service Defaults

### DIFF
--- a/Gallery.Api/Gallery.Api.csproj
+++ b/Gallery.Api/Gallery.Api.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="9.0.0" />
     <PackageReference Include="steamfitter.api.client" Version="1.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageReference Include="Crucible.Common.ServiceDefaults" Version="0.0.2"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Gallery.Api.Data\Gallery.Api.Data.csproj" />

--- a/Gallery.Api/Startup.cs
+++ b/Gallery.Api/Startup.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using AutoMapper.Internal;
+using Crucible.Common.ServiceDefaults;
 
 namespace Gallery.Api;
 
@@ -43,9 +44,11 @@ public class Startup
     private const string _routePrefix = "api";
     private string _pathbase;
     private readonly SignalROptions _signalROptions = new();
+    private readonly IWebHostEnvironment _env;
 
-    public Startup(IConfiguration configuration)
+    public Startup(IConfiguration configuration, IWebHostEnvironment env)
     {
+        _env = env;
         Configuration = configuration;
         Configuration.GetSection("Authorization").Bind(_authOptions);
         Configuration.GetSection("XApiOptions").Bind(_xApiOptions);
@@ -233,6 +236,17 @@ public class Startup
             .AddScoped(config => config.GetService<IOptionsMonitor<ResourceOwnerAuthorizationOptions>>().CurrentValue);
 
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(Startup).Assembly));
+
+        // add Crucible Common Service Defaults with configuration from appsettings
+        services.AddServiceDefaults(_env, Configuration, openTelemetryOptions =>
+        {
+            // Bind configuration from appsettings.json "OpenTelemetry" section
+            var telemetrySection = Configuration.GetSection("OpenTelemetry");
+            if (telemetrySection.Exists())
+            {
+                telemetrySection.Bind(openTelemetryOptions);
+            }
+        });
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Gallery.Api/appsettings.json
+++ b/Gallery.Api/appsettings.json
@@ -82,6 +82,13 @@
   "ApplicationInsights": {
     "ConnectionString": ""
   },
+  "OpenTelemetry": {
+    "AddAlwaysOnTracingSampler": false,
+    "AddConsoleExporter": false,
+    "AddPrometheusExporter": false,
+    "IncludeDefaultActivitySources": true,
+    "IncludeDefaultMeters": true
+  },
   "SignalR": {
     "EnableStatefulReconnect": true,
     "StatefulReconnectBufferSizeBytes": 100000


### PR DESCRIPTION
Adds OpenTelemetry with Crucible ServiceDefaults implementation

- Adds ServiceDefaults settings to appsettings.json, allowing the user to specify options for the ServiceDefaults library
- Adjust Startup.cs to configure Otel via ServiceDefaults


Tested using Crucible Dev Container - Deployed Blueprint profile and observed all metrics, traces, and structured logs appearing in the Aspire Dashboard as intended.

Based changes made on the similar [PR to Blueprint.Api](https://github.com/cmu-sei/Blueprint.Api/pull/140).

Helm values will need to be updated to reflect the new OpenTelemetry settings. I can handle that in the Helm chart PR that is created once the changes are released.