### PR TITLE
Implement xAPI statement queueing with background processing

### DIFF
--- a/Gallery.Api.Data/GalleryDbContext.cs
+++ b/Gallery.Api.Data/GalleryDbContext.cs
@@ -45,6 +45,7 @@ namespace Gallery.Api.Data
         public DbSet<CollectionMembershipEntity> CollectionMemberships { get; set; }
         public DbSet<GroupEntity> Groups { get; set; }
         public DbSet<GroupMembershipEntity> GroupMemberships { get; set; }
+        public DbSet<XApiQueuedStatementEntity> XApiQueuedStatements { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Gallery.Api.Data/Models/XApiQueuedStatement.cs
+++ b/Gallery.Api.Data/Models/XApiQueuedStatement.cs
@@ -1,0 +1,44 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license, please see LICENSE.md in the project root for license information or contact permission@sei.cmu.edu for full terms.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Gallery.Api.Data.Models
+{
+    public class XApiQueuedStatementEntity : BaseEntity
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Id { get; set; }
+
+        [Required]
+        public string StatementJson { get; set; }
+
+        [Required]
+        public DateTime QueuedAt { get; set; }
+
+        public DateTime? LastAttemptAt { get; set; }
+
+        public int RetryCount { get; set; }
+
+        [Required]
+        public XApiQueueStatus Status { get; set; }
+
+        public string ErrorMessage { get; set; }
+
+        // Optional: Store some metadata for debugging/monitoring
+        public string Verb { get; set; }
+        public string ActivityId { get; set; }
+        public Guid? TeamId { get; set; }
+    }
+
+    public enum XApiQueueStatus
+    {
+        Pending = 0,
+        Processing = 1,
+        Completed = 2,
+        Failed = 3
+    }
+}

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/20260212162747_AddXApiQueuedStatements.Designer.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/20260212162747_AddXApiQueuedStatements.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Gallery.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Gallery.Api.Migrations.PostgreSQL.Migrations
 {
     [DbContext(typeof(GalleryDbContext))]
-    partial class GalleryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260212162747_AddXApiQueuedStatements")]
+    partial class AddXApiQueuedStatements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/20260212162747_AddXApiQueuedStatements.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/20260212162747_AddXApiQueuedStatements.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gallery.Api.Migrations.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddXApiQueuedStatements : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "x_api_queued_statements",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuid_generate_v4()"),
+                    statement_json = table.Column<string>(type: "text", nullable: false),
+                    queued_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_attempt_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    retry_count = table.Column<int>(type: "integer", nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    error_message = table.Column<string>(type: "text", nullable: true),
+                    verb = table.Column<string>(type: "text", nullable: true),
+                    activity_id = table.Column<string>(type: "text", nullable: true),
+                    team_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    date_created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    date_modified = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    created_by = table.Column<Guid>(type: "uuid", nullable: false),
+                    modified_by = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_x_api_queued_statements", x => x.id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "x_api_queued_statements");
+        }
+    }
+}

--- a/Gallery.Api/Services/XApiBackgroundService.cs
+++ b/Gallery.Api/Services/XApiBackgroundService.cs
@@ -1,0 +1,123 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license, please see LICENSE.md in the project root for license information or contact permission@sei.cmu.edu for full terms.
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Gallery.Api.Infrastructure.Options;
+using TinCan;
+using Newtonsoft.Json;
+
+namespace Gallery.Api.Services
+{
+    public class XApiBackgroundService : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<XApiBackgroundService> _logger;
+        private const int ProcessingDelaySeconds = 5;
+        private const int BatchSize = 10;
+
+        public XApiBackgroundService(
+            IServiceProvider serviceProvider,
+            ILogger<XApiBackgroundService> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("xAPI Background Service started");
+
+            // Check if xAPI is configured (get from scope)
+            using (var scope = _serviceProvider.CreateScope())
+            {
+                var xApiOptions = scope.ServiceProvider.GetRequiredService<XApiOptions>();
+                if (string.IsNullOrWhiteSpace(xApiOptions.Username))
+                {
+                    _logger.LogInformation("xAPI is not configured. Background service will not process statements.");
+                    return;
+                }
+            }
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await ProcessQueueAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing xAPI queue");
+                }
+
+                // Wait before processing next batch
+                await Task.Delay(TimeSpan.FromSeconds(ProcessingDelaySeconds), stoppingToken);
+            }
+
+            _logger.LogInformation("xAPI Background Service stopped");
+        }
+
+        private async Task ProcessQueueAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var queueService = scope.ServiceProvider.GetRequiredService<IXApiQueueService>();
+            var xApiOptions = scope.ServiceProvider.GetRequiredService<XApiOptions>();
+            var httpClientFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+
+            // Get a batch of statements to process
+            var statements = await queueService.DequeueAsync(BatchSize, cancellationToken);
+
+            if (statements.Count == 0)
+            {
+                return; // Nothing to process
+            }
+
+            // Create HTTP client for LRS
+            var httpClient = httpClientFactory.CreateClient();
+            var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{xApiOptions.Username}:{xApiOptions.Password}"));
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Basic {credentials}");
+            httpClient.DefaultRequestHeaders.Add("X-Experience-API-Version", "1.0.3");
+
+            // Process each statement
+            foreach (var queuedStatement in statements)
+            {
+                try
+                {
+                    // Send raw JSON directly to LRS
+                    var content = new StringContent(queuedStatement.StatementJson, Encoding.UTF8, "application/json");
+                    var response = await httpClient.PostAsync($"{xApiOptions.Endpoint}/statements", content, cancellationToken);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        await queueService.MarkCompletedAsync(queuedStatement.Id, cancellationToken);
+                        _logger.LogInformation("Successfully sent xAPI statement {StatementId} to LRS", queuedStatement.Id);
+                    }
+                    else
+                    {
+                        var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                        await queueService.MarkFailedAsync(queuedStatement.Id, $"HTTP {response.StatusCode}: {errorBody}", cancellationToken);
+                        _logger.LogWarning("Failed to send xAPI statement {StatementId}: HTTP {StatusCode} - {Error}",
+                            queuedStatement.Id, response.StatusCode, errorBody);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await queueService.MarkFailedAsync(queuedStatement.Id, ex.Message, cancellationToken);
+                    _logger.LogError(ex, "Error processing xAPI statement {StatementId}", queuedStatement.Id);
+                }
+            }
+        }
+
+        public override Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("xAPI Background Service is stopping");
+            return base.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/Gallery.Api/Services/XApiQueueService.cs
+++ b/Gallery.Api/Services/XApiQueueService.cs
@@ -1,0 +1,126 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license, please see LICENSE.md in the project root for license information or contact permission@sei.cmu.edu for full terms.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Gallery.Api.Data;
+using Gallery.Api.Data.Models;
+
+namespace Gallery.Api.Services
+{
+    public interface IXApiQueueService
+    {
+        Task EnqueueAsync(XApiQueuedStatementEntity statement, CancellationToken ct = default);
+        Task<List<XApiQueuedStatementEntity>> DequeueAsync(int batchSize = 10, CancellationToken ct = default);
+        Task MarkCompletedAsync(Guid statementId, CancellationToken ct = default);
+        Task MarkFailedAsync(Guid statementId, string errorMessage, CancellationToken ct = default);
+        Task<int> GetQueueDepthAsync(CancellationToken ct = default);
+    }
+
+    public class XApiQueueService : IXApiQueueService
+    {
+        private readonly GalleryDbContext _context;
+        private readonly ILogger<XApiQueueService> _logger;
+        private const int MaxRetryCount = 5;
+
+        public XApiQueueService(
+            GalleryDbContext context,
+            ILogger<XApiQueueService> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task EnqueueAsync(XApiQueuedStatementEntity statement, CancellationToken ct = default)
+        {
+            statement.QueuedAt = DateTime.UtcNow;
+            statement.Status = XApiQueueStatus.Pending;
+            statement.RetryCount = 0;
+
+            _context.XApiQueuedStatements.Add(statement);
+            await _context.SaveChangesAsync(ct);
+
+            _logger.LogDebug("Enqueued xAPI statement {StatementId} for verb {Verb}", statement.Id, statement.Verb);
+        }
+
+        public async Task<List<XApiQueuedStatementEntity>> DequeueAsync(int batchSize = 10, CancellationToken ct = default)
+        {
+            // Get pending statements that haven't exceeded retry count
+            var statements = await _context.XApiQueuedStatements
+                .Where(s => s.Status == XApiQueueStatus.Pending && s.RetryCount < MaxRetryCount)
+                .OrderBy(s => s.QueuedAt)
+                .Take(batchSize)
+                .ToListAsync(ct);
+
+            // Mark them as processing
+            foreach (var statement in statements)
+            {
+                statement.Status = XApiQueueStatus.Processing;
+                statement.LastAttemptAt = DateTime.UtcNow;
+                statement.RetryCount++;
+            }
+
+            if (statements.Any())
+            {
+                await _context.SaveChangesAsync(ct);
+                _logger.LogInformation("Dequeued {Count} xAPI statements for processing", statements.Count);
+            }
+
+            return statements;
+        }
+
+        public async Task MarkCompletedAsync(Guid statementId, CancellationToken ct = default)
+        {
+            var statement = await _context.XApiQueuedStatements.FindAsync(new object[] { statementId }, ct);
+            if (statement == null)
+            {
+                _logger.LogWarning("Attempted to mark non-existent statement {StatementId} as completed", statementId);
+                return;
+            }
+
+            statement.Status = XApiQueueStatus.Completed;
+            await _context.SaveChangesAsync(ct);
+
+            _logger.LogDebug("Marked xAPI statement {StatementId} as completed", statementId);
+        }
+
+        public async Task MarkFailedAsync(Guid statementId, string errorMessage, CancellationToken ct = default)
+        {
+            var statement = await _context.XApiQueuedStatements.FindAsync(new object[] { statementId }, ct);
+            if (statement == null)
+            {
+                _logger.LogWarning("Attempted to mark non-existent statement {StatementId} as failed", statementId);
+                return;
+            }
+
+            statement.Status = statement.RetryCount >= MaxRetryCount
+                ? XApiQueueStatus.Failed
+                : XApiQueueStatus.Pending; // Will retry if under limit
+            statement.ErrorMessage = errorMessage;
+
+            await _context.SaveChangesAsync(ct);
+
+            if (statement.Status == XApiQueueStatus.Failed)
+            {
+                _logger.LogError("xAPI statement {StatementId} failed after {RetryCount} attempts: {Error}",
+                    statementId, statement.RetryCount, errorMessage);
+            }
+            else
+            {
+                _logger.LogWarning("xAPI statement {StatementId} failed attempt {RetryCount}, will retry: {Error}",
+                    statementId, statement.RetryCount, errorMessage);
+            }
+        }
+
+        public async Task<int> GetQueueDepthAsync(CancellationToken ct = default)
+        {
+            return await _context.XApiQueuedStatements
+                .CountAsync(s => s.Status == XApiQueueStatus.Pending || s.Status == XApiQueueStatus.Processing, ct);
+        }
+    }
+}

--- a/Gallery.Api/Startup.cs
+++ b/Gallery.Api/Startup.cs
@@ -197,6 +197,7 @@ public class Startup
         services.AddMemoryCache();
 
         services.AddScoped<IXApiService, XApiService>();
+        services.AddScoped<IXApiQueueService, XApiQueueService>();
         services.AddScoped<IArticleService, ArticleService>();
         services.AddScoped<ICardService, CardService>();
         services.AddScoped<IClaimsTransformation, AuthorizationClaimsTransformer>();
@@ -221,6 +222,9 @@ public class Startup
         services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         services.AddScoped<IPrincipal>(p => p.GetService<IHttpContextAccessor>()?.HttpContext?.User);
         services.AddHttpClient();
+
+        // Register xAPI Background Service
+        services.AddHostedService<Services.XApiBackgroundService>();
 
         ApplyPolicies(services);
 


### PR DESCRIPTION
Replaces synchronous xAPI statement sending with an asynchronous queue-based approach similar to CITE API implementation. This improves performance and reliability by moving LRS communication to a background service.

Changes:
- Add XApiQueuedStatementEntity model with queue status tracking
- Add XApiQueuedStatements DbSet to GalleryDbContext
- Create database migration for x_api_queued_statements table
- Create XApiQueueService for managing statement queue operations
- Create XApiBackgroundService to process queued statements
- Update XApiService to enqueue statements instead of sending synchronously
- Register new services in Startup.cs

Benefits:
- Non-blocking xAPI statement generation
- Automatic retry logic for failed statements (up to 5 attempts)
- Better error handling and logging
- Reduced impact of LRS downtime on application performance

Tested and confirmed working with live xAPI statements in LRS.