### PR TITLE
Standardize launchUrl to 'api' for Aspire dashboard

### DIFF
--- a/Gallery.Api/Properties/launchSettings.json
+++ b/Gallery.Api/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Api": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:4722/api/index.html",
+      "launchUrl": "api",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
Changed launchUrl from 'http://localhost:4722/api/index.html' to 'api' to ensure consistent URL display in the .NET Aspire dashboard.