### PR TITLE
Change docker image to use dotnet 10 chiseled base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.md
+appsettings.*.json
+**/appsettings.*.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
     uses: cmu-sei/Crucible-Github-Actions/.github/workflows/docker-build.yaml@docker-v1.0
     with:
       imageName: cmusei/gallery-api
+      additionalTarget: debug
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ bin/
 obj/
 *.user
 .vs/
-appsettings.Development.json
+**/appsettings.*.json
 .vscode/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,38 @@
-#
-#multi-stage target: dev
-#
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS dev
+# Adapted from https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile.chiseled
 
-ENV ASPNETCORE_HTTP_PORTS=4302
-ENV ASPNETCORE_ENVIRONMENT=DEVELOPMENT
+# Build stage
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+WORKDIR /source
 
-COPY . /app
-WORKDIR /app/Gallery.Api
-RUN dotnet publish -c Release -o /app/dist
-CMD ["dotnet", "run"]
+# Copy project files and restore as distinct layers
+COPY --link Gallery.Api/*.csproj ./Gallery.Api/
+COPY --link Gallery.Api.Data/*.csproj ./Gallery.Api.Data/
+COPY --link Gallery.Api.Migrations.PostgreSQL/*.csproj ./Gallery.Api.Migrations.PostgreSQL/
+WORKDIR /source/Gallery.Api
+RUN dotnet restore -a $TARGETARCH
 
-#
-#multi-stage target: prod
-#
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS prod
+# Copy source code and publish app
+WORKDIR /source
+COPY --link . .
+WORKDIR /source/Gallery.Api
+RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+
+# Debug Stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS debug
 ENV DOTNET_HOSTBUILDER__RELOADCONFIGCHANGE=false
-COPY --from=dev /app/dist /app
-
+EXPOSE 8080
 WORKDIR /app
-ENV ASPNETCORE_HTTP_PORTS=80
-EXPOSE 80
+COPY --link --from=build /app .
+USER $APP_UID
+ENTRYPOINT ["./Gallery.Api"]
 
-CMD [ "dotnet", "Gallery.Api.dll" ]
+# Production stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled AS prod
+ARG commit
+ENV COMMIT=$commit
+ENV DOTNET_HOSTBUILDER__RELOADCONFIGCHANGE=false
+EXPOSE 8080
+WORKDIR /app
+COPY --link --from=build /app .
+ENTRYPOINT ["./Gallery.Api"]


### PR DESCRIPTION
Changed the docker image to use the dotnet 10 chiseled base for enhanced security. Followed the precedent set by [Player.Api](https://github.com/cmu-sei/Player.Api/releases/tag/3.4.0). 

Tested by deploying the app via Aspire in the dev container. Also built a local docker image and tested via a helm deployment in minikube via the dev container. 

Helm chart updates are needed. I will add the changes to the Helm chart PR that is created automatically upon app release. 