### PR TITLE
Fix/content developer permissions

### DIFF
--- a/Gallery.Api.Data/Models/SystemRole.cs
+++ b/Gallery.Api.Data/Models/SystemRole.cs
@@ -55,6 +55,10 @@ public class SystemRoleEntityConfiguration : IEntityTypeConfiguration<SystemRole
                 AllPermissions = false,
                 Immutable = false,
                 Permissions = [
+                    SystemPermission.ViewCollections,
+                    SystemPermission.ViewExhibits,
+                    SystemPermission.ViewRoles,
+                    SystemPermission.ViewGroups,
                     SystemPermission.CreateCollections,
                     SystemPermission.CreateExhibits,
                     SystemPermission.ManageExhibits

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/20260319114338_AddViewPermissionsToContentDeveloper.Designer.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/20260319114338_AddViewPermissionsToContentDeveloper.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Gallery.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Gallery.Api.Migrations.PostgreSQL.Migrations
 {
     [DbContext(typeof(GalleryDbContext))]
-    partial class GalleryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260319114338_AddViewPermissionsToContentDeveloper")]
+    partial class AddViewPermissionsToContentDeveloper
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/20260319114338_AddViewPermissionsToContentDeveloper.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/20260319114338_AddViewPermissionsToContentDeveloper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gallery.Api.Migrations.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddViewPermissionsToContentDeveloper : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "system_roles",
+                keyColumn: "id",
+                keyValue: new Guid("d80b73c3-95d7-4468-8650-c62bbd082507"),
+                column: "permissions",
+                value: new[] { 1, 5, 10, 12, 0, 4, 7 });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "system_roles",
+                keyColumn: "id",
+                keyValue: new Guid("d80b73c3-95d7-4468-8650-c62bbd082507"),
+                column: "permissions",
+                value: new[] { 0, 4, 7 });
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary
  - Add View permissions to ContentDeveloper system role default permissions

  ## Changes
  Expands the default permissions for ContentDeveloper role to include:
  - `ViewCollections`
  - `ViewExhibits`
  - `ViewRoles`
  - `ViewGroups`

  This allows ContentDevelopers to view administrative sections without requiring manual permission grants, while maintaining the existing Create/Manage permissions they already have.

  ## Test Plan
  - [ ] Verify ContentDevelopers can access admin sections to view collections, exhibits, roles, and groups
  - [ ] Verify ContentDevelopers can still create and manage exhibits as before
  - [ ] Verify other roles (Administrator, BasicUser) are unaffected
