### PR TITLE
Add ShowAdvanceButton property and advance exhibit endpoint

### DIFF
--- a/Gallery.Api.Data/Models/Exhibit.cs
+++ b/Gallery.Api.Data/Models/Exhibit.cs
@@ -18,6 +18,7 @@ namespace Gallery.Api.Data.Models
         public Guid CollectionId { get; set; }
         public CollectionEntity Collection { get; set; }
         public Guid? ScenarioId { get; set; }
+        public bool ShowAdvanceButton { get; set; }
         public ICollection<TeamEntity> Teams { get; set; } = new List<TeamEntity>();
         public string Name { get; set; }
         public string Description { get; set; }

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/20260410174556_add-show-advance-button.Designer.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/20260410174556_add-show-advance-button.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Gallery.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Gallery.Api.Migrations.PostgreSQL.Migrations
 {
     [DbContext(typeof(GalleryDbContext))]
-    partial class GalleryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410174556_add-show-advance-button")]
+    partial class addshowadvancebutton
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/20260410174556_add-show-advance-button.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/20260410174556_add-show-advance-button.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Gallery.Api.Migrations.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class addshowadvancebutton : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "show_advance_button",
+                table: "exhibits",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Set existing exhibits to show the advance button
+            migrationBuilder.Sql("UPDATE exhibits SET show_advance_button = true");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "show_advance_button",
+                table: "exhibits");
+        }
+    }
+}

--- a/Gallery.Api/Controllers/ExhibitController.cs
+++ b/Gallery.Api/Controllers/ExhibitController.cs
@@ -255,6 +255,38 @@ namespace Gallery.Api.Controllers
         }
 
         /// <summary>
+        /// Advances an Exhibit to the next move/inject
+        /// </summary>
+        /// <remarks>
+        /// Looks at all articles for unique moves and injects, sorts by move then inject,
+        /// finds the current position, and advances to the next higher inject or
+        /// the next higher move if at the highest inject for the current move.
+        /// Returns an error if already at the last move/inject.
+        /// </remarks>
+        /// <param name="id">The Id of the Exhibit to advance</param>
+        /// <param name="ct"></param>
+        [HttpPut("exhibits/{id}/advance")]
+        [ProducesResponseType(typeof(Exhibit), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.BadRequest)]
+        [SwaggerOperation(OperationId = "advanceExhibit")]
+        public async Task<IActionResult> AdvanceExhibit([FromRoute] Guid id, CancellationToken ct)
+        {
+            if (!await _authorizationService.AuthorizeAsync<Exhibit>(id, [SystemPermission.ManageExhibits], [ExhibitPermission.ManageExhibit], ct))
+                throw new ForbiddenException();
+
+            var updatedExhibit = await _exhibitService.AdvanceAsync(id, ct);
+            if (updatedExhibit == null)
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Cannot advance.",
+                    Detail = "Already at the last move/inject. There are no further moves or injects to advance to.",
+                    Status = (int)HttpStatusCode.BadRequest
+                });
+
+            return Ok(updatedExhibit);
+        }
+
+        /// <summary>
         /// Deletes an Exhibit
         /// </summary>
         /// <remarks>

--- a/Gallery.Api/Services/ExhibitService.cs
+++ b/Gallery.Api/Services/ExhibitService.cs
@@ -38,6 +38,7 @@ namespace Gallery.Api.Services
         Task<Exhibit> UploadJsonAsync(FileForm form, CancellationToken ct);
         Task<ViewModels.Exhibit> UpdateAsync(Guid id, ViewModels.Exhibit exhibit, CancellationToken ct);
         Task<ViewModels.Exhibit> SetMoveAndInjectAsync(Guid id, int move, int inject, CancellationToken ct);
+        Task<ViewModels.Exhibit> AdvanceAsync(Guid id, CancellationToken ct);
         Task<bool> DeleteAsync(Guid id, CancellationToken ct);
     }
 
@@ -425,6 +426,45 @@ namespace Gallery.Api.Services
 
             exhibitToUpdate.CurrentMove = move;
             exhibitToUpdate.CurrentInject = inject;
+            await _context.SaveChangesAsync(ct);
+            await _userArticleService.LoadUserArticlesAsync(exhibitToUpdate, ct);
+
+            var updatedExhibit = await GetAsync(exhibitToUpdate.Id, false, ct);
+
+            return updatedExhibit;
+        }
+
+        public async Task<ViewModels.Exhibit> AdvanceAsync(Guid id, CancellationToken ct)
+        {
+            var exhibitToUpdate = await _context.Exhibits.SingleOrDefaultAsync(v => v.Id == id, ct);
+            if (exhibitToUpdate == null)
+                throw new EntityNotFoundException<Exhibit>();
+
+            // Get all unique move/inject pairs from articles in this exhibit's collection
+            var moveInjectPairs = await _context.Articles
+                .Where(a => a.CollectionId == exhibitToUpdate.CollectionId
+                    && (a.ExhibitId == null || a.ExhibitId == id))
+                .Select(a => new { a.Move, a.Inject })
+                .Distinct()
+                .OrderBy(a => a.Move)
+                .ThenBy(a => a.Inject)
+                .ToListAsync(ct);
+
+            var currentMove = exhibitToUpdate.CurrentMove;
+            var currentInject = exhibitToUpdate.CurrentInject;
+
+            // Find the next move/inject pair after the current position
+            var nextPair = moveInjectPairs
+                .Where(p => p.Move > currentMove || (p.Move == currentMove && p.Inject > currentInject))
+                .OrderBy(p => p.Move)
+                .ThenBy(p => p.Inject)
+                .FirstOrDefault();
+
+            if (nextPair == null)
+                return null;
+
+            exhibitToUpdate.CurrentMove = nextPair.Move;
+            exhibitToUpdate.CurrentInject = nextPair.Inject;
             await _context.SaveChangesAsync(ct);
             await _userArticleService.LoadUserArticlesAsync(exhibitToUpdate, ct);
 

--- a/Gallery.Api/ViewModels/Exhibit.cs
+++ b/Gallery.Api/ViewModels/Exhibit.cs
@@ -13,6 +13,7 @@ namespace Gallery.Api.ViewModels
         public int CurrentInject { get; set; }
         public Guid CollectionId { get; set; }
         public Guid? ScenarioId { get; set; }
+        public bool ShowAdvanceButton { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
         public IEnumerable<string> ExhibitPermissions { get; set; }


### PR DESCRIPTION
Adds a ShowAdvanceButton boolean to the Exhibit model with a
  corresponding database migration. Adds a PUT endpoint at
  /api/exhibits/{id}/advance that advances an exhibit to the next
  move/inject based on its article positions