### PR TITLE
Feature/gallery xapi grouping standardization

### DIFF
--- a/Gallery.Api/Services/UserArticleService.cs
+++ b/Gallery.Api/Services/UserArticleService.cs
@@ -619,9 +619,9 @@ namespace Gallery.Api.Services
                 var moveGrouping = new Dictionary<String,String>();
                 moveGrouping.Add("id", article.Move.ToString());
                 moveGrouping.Add("name", $"Move {article.Move}");
-                moveGrouping.Add("description", $"Article move: {article.Move}. Current exhibit move: {exhibit.CurrentMove}");
-                moveGrouping.Add("type", "move");
-                moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+                moveGrouping.Add("description", "");
+                moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
+                moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
                 grouping.Add(moveGrouping);
 
@@ -629,8 +629,8 @@ namespace Gallery.Api.Services
                 var injectGrouping = new Dictionary<String,String>();
                 injectGrouping.Add("id", article.Inject.ToString());
                 injectGrouping.Add("name", $"Inject {article.Inject}");
-                injectGrouping.Add("description", $"Article inject: {article.Inject}. Current exhibit inject: {exhibit.CurrentInject}");
-                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("description", "");
+                injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
                 grouping.Add(injectGrouping);

--- a/Gallery.Api/Services/XApiService.cs
+++ b/Gallery.Api/Services/XApiService.cs
@@ -147,7 +147,7 @@ namespace Gallery.Api.Services
             moveGrouping.Add("id", article.Move.ToString());
             moveGrouping.Add("name", $"Move {article.Move}");
             moveGrouping.Add("description", "");
-            moveGrouping.Add("type", "move");
+            moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
             moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
             moveGrouping.Add("moreInfo", "");
             grouping.Add(moveGrouping);
@@ -157,7 +157,7 @@ namespace Gallery.Api.Services
             injectGrouping.Add("id", article.Inject.ToString());
             injectGrouping.Add("name", $"Inject {article.Inject}");
             injectGrouping.Add("description", "");
-            injectGrouping.Add("type", "inject");
+            injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
             injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
             injectGrouping.Add("moreInfo", "");
             grouping.Add(injectGrouping);
@@ -215,7 +215,7 @@ namespace Gallery.Api.Services
             moveGrouping.Add("id", article.Move.ToString());
             moveGrouping.Add("name", $"Move {article.Move}");
             moveGrouping.Add("description", "");
-            moveGrouping.Add("type", "move");
+            moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
             moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
             moveGrouping.Add("moreInfo", "");
             grouping.Add(moveGrouping);
@@ -225,7 +225,7 @@ namespace Gallery.Api.Services
             injectGrouping.Add("id", article.Inject.ToString());
             injectGrouping.Add("name", $"Inject {article.Inject}");
             injectGrouping.Add("description", "");
-            injectGrouping.Add("type", "inject");
+            injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
             injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
             injectGrouping.Add("moreInfo", "");
             grouping.Add(injectGrouping);
@@ -313,7 +313,7 @@ namespace Gallery.Api.Services
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
                 moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
                 moveGrouping.Add("description", "");
-                moveGrouping.Add("type", "move");
+                moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
                 grouping.Add(moveGrouping);
@@ -322,7 +322,7 @@ namespace Gallery.Api.Services
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
                 injectGrouping.Add("description", "");
-                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
                 grouping.Add(injectGrouping);
@@ -368,7 +368,7 @@ namespace Gallery.Api.Services
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
                 moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
                 moveGrouping.Add("description", "");
-                moveGrouping.Add("type", "move");
+                moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
                 grouping.Add(moveGrouping);
@@ -377,7 +377,7 @@ namespace Gallery.Api.Services
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
                 injectGrouping.Add("description", "");
-                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
                 grouping.Add(injectGrouping);
@@ -421,7 +421,7 @@ namespace Gallery.Api.Services
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
                 moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
                 moveGrouping.Add("description", "");
-                moveGrouping.Add("type", "move");
+                moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
                 grouping.Add(moveGrouping);
@@ -430,7 +430,7 @@ namespace Gallery.Api.Services
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
                 injectGrouping.Add("description", "");
-                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
                 grouping.Add(injectGrouping);
@@ -475,7 +475,7 @@ namespace Gallery.Api.Services
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
                 moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
                 moveGrouping.Add("description", "");
-                moveGrouping.Add("type", "move");
+                moveGrouping.Add("type", $"exhibit/{exhibit.Id}/move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
                 grouping.Add(moveGrouping);
@@ -484,7 +484,7 @@ namespace Gallery.Api.Services
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
                 injectGrouping.Add("description", "");
-                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("type", $"exhibit/{exhibit.Id}/inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
                 grouping.Add(injectGrouping);
@@ -526,7 +526,7 @@ namespace Gallery.Api.Services
             activity.definition = new TinCan.ActivityDefinition();
             activity.definition.type = new Uri(activityData["activityType"]);
             if (activityData.ContainsKey("moreInfo")) {
-                activity.definition.moreInfo = new Uri(_xApiOptions.UiUrl + activityData["moreInfo"]);
+                activity.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + activityData["moreInfo"]);
             }
             activity.definition.name = new LanguageMap();
             activity.definition.name.Add("en-US", activityData["name"]);
@@ -580,7 +580,7 @@ namespace Gallery.Api.Services
                 }
                 parent.definition.type = new Uri(parentData["activityType"]);
                 if (parentData.ContainsKey("moreInfo")) {
-                    parent.definition.moreInfo = new Uri(_xApiOptions.UiUrl + parentData["moreInfo"]);
+                    parent.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + parentData["moreInfo"]);
                 }
                 contextActivities.parent = new List<Activity>();
                 contextActivities.parent.Add(parent);
@@ -598,7 +598,7 @@ namespace Gallery.Api.Services
                 }
                 other.definition.type = new Uri(otherData["activityType"]);
                 if (otherData.ContainsKey("moreInfo")) {
-                    other.definition.moreInfo = new Uri(_xApiOptions.UiUrl + otherData["moreInfo"]);
+                    other.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + otherData["moreInfo"]);
                 }
                 contextActivities.other = new List<Activity>();
                 context.contextActivities.other.Add(other);
@@ -621,7 +621,7 @@ namespace Gallery.Api.Services
                         }
                         grouping.definition.type = new Uri(groupingItem["activityType"]);
                         if (groupingItem.ContainsKey("moreInfo") && !string.IsNullOrEmpty(groupingItem["moreInfo"])) {
-                            grouping.definition.moreInfo = new Uri(_xApiOptions.UiUrl + groupingItem["moreInfo"]);
+                            grouping.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + groupingItem["moreInfo"]);
                         }
                         context.contextActivities.grouping.Add(grouping);
                     }
@@ -640,7 +640,7 @@ namespace Gallery.Api.Services
                 }
                 category.definition.type = new Uri(categoryData["activityType"]);
                 if (categoryData.ContainsKey("moreInfo")) {
-                    category.definition.moreInfo = new Uri(_xApiOptions.UiUrl + categoryData["moreInfo"]);
+                    category.definition.moreInfo = new Uri(_xApiOptions.UiUrl.TrimEnd('/') + categoryData["moreInfo"]);
                 }
                 contextActivities.category = new List<Activity>();
                 context.contextActivities.category.Add(category);

--- a/Gallery.Api/Services/XApiService.cs
+++ b/Gallery.Api/Services/XApiService.cs
@@ -145,10 +145,10 @@ namespace Gallery.Api.Services
             // Move grouping entry
             var moveGrouping = new Dictionary<String,String>();
             moveGrouping.Add("id", article.Move.ToString());
-            moveGrouping.Add("name", $"Move {article.Move}");
-            moveGrouping.Add("description", $"Article move: {article.Move}. Current exhibit move: {exhibit.CurrentMove}");
+            moveGrouping.Add("name", article.Name);
+            moveGrouping.Add("description", article.Summary);
             moveGrouping.Add("type", "move");
-            moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+            moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
             moveGrouping.Add("moreInfo", "");
             grouping.Add(moveGrouping);
 
@@ -213,10 +213,10 @@ namespace Gallery.Api.Services
             // Move grouping entry
             var moveGrouping = new Dictionary<String,String>();
             moveGrouping.Add("id", article.Move.ToString());
-            moveGrouping.Add("name", $"Move {article.Move}");
-            moveGrouping.Add("description", $"Article move: {article.Move}. Current exhibit move: {exhibit.CurrentMove}");
+            moveGrouping.Add("name", article.Name);
+            moveGrouping.Add("description", article.Summary);
             moveGrouping.Add("type", "move");
-            moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+            moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
             moveGrouping.Add("moreInfo", "");
             grouping.Add(moveGrouping);
 
@@ -307,6 +307,27 @@ namespace Gallery.Api.Services
             var grouping = new List<Dictionary<String,String>>();
             var other = new Dictionary<String,String>();
 
+            if (exhibit.CurrentMove >= 0 || exhibit.CurrentInject >= 0)
+            {
+                var moveGrouping = new Dictionary<String,String>();
+                moveGrouping.Add("id", exhibit.CurrentMove.ToString());
+                moveGrouping.Add("name", "Current Move");
+                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("type", "move");
+                moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
+                moveGrouping.Add("moreInfo", "");
+                grouping.Add(moveGrouping);
+
+                var injectGrouping = new Dictionary<String,String>();
+                injectGrouping.Add("id", exhibit.CurrentInject.ToString());
+                injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
+                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+                injectGrouping.Add("moreInfo", "");
+                grouping.Add(injectGrouping);
+            }
+
             return await CreateAsync(
                 verb, activity, category, grouping, parent, other, teamId, ct);
 
@@ -341,6 +362,27 @@ namespace Gallery.Api.Services
             var grouping = new List<Dictionary<String,String>>();
             var other = new Dictionary<String,String>();
 
+            if (exhibit.CurrentMove >= 0 || exhibit.CurrentInject >= 0)
+            {
+                var moveGrouping = new Dictionary<String,String>();
+                moveGrouping.Add("id", exhibit.CurrentMove.ToString());
+                moveGrouping.Add("name", "Current Move");
+                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("type", "move");
+                moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
+                moveGrouping.Add("moreInfo", "");
+                grouping.Add(moveGrouping);
+
+                var injectGrouping = new Dictionary<String,String>();
+                injectGrouping.Add("id", exhibit.CurrentInject.ToString());
+                injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
+                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+                injectGrouping.Add("moreInfo", "");
+                grouping.Add(injectGrouping);
+            }
+
             return await CreateAsync(
                 verb, activity, category, grouping, parent, other, teamId, ct);
 
@@ -372,6 +414,27 @@ namespace Gallery.Api.Services
             var category = new Dictionary<String,String>();
             var grouping = new List<Dictionary<String,String>>();
             var other = new Dictionary<String,String>();
+
+            if (exhibit.CurrentMove >= 0 || exhibit.CurrentInject >= 0)
+            {
+                var moveGrouping = new Dictionary<String,String>();
+                moveGrouping.Add("id", exhibit.CurrentMove.ToString());
+                moveGrouping.Add("name", "Current Move");
+                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("type", "move");
+                moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
+                moveGrouping.Add("moreInfo", "");
+                grouping.Add(moveGrouping);
+
+                var injectGrouping = new Dictionary<String,String>();
+                injectGrouping.Add("id", exhibit.CurrentInject.ToString());
+                injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
+                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+                injectGrouping.Add("moreInfo", "");
+                grouping.Add(injectGrouping);
+            }
 
             return await CreateAsync(
                 verb, activity, category, grouping, parent, other, teamId, ct);
@@ -405,6 +468,27 @@ namespace Gallery.Api.Services
             var category = new Dictionary<String,String>();
             var grouping = new List<Dictionary<String,String>>();
             var other = new Dictionary<String,String>();
+
+            if (exhibit.CurrentMove >= 0 || exhibit.CurrentInject >= 0)
+            {
+                var moveGrouping = new Dictionary<String,String>();
+                moveGrouping.Add("id", exhibit.CurrentMove.ToString());
+                moveGrouping.Add("name", "Current Move");
+                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("type", "move");
+                moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
+                moveGrouping.Add("moreInfo", "");
+                grouping.Add(moveGrouping);
+
+                var injectGrouping = new Dictionary<String,String>();
+                injectGrouping.Add("id", exhibit.CurrentInject.ToString());
+                injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
+                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("type", "inject");
+                injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
+                injectGrouping.Add("moreInfo", "");
+                grouping.Add(injectGrouping);
+            }
 
             return await CreateAsync(
                 verb, activity, category, grouping, parent, other, teamId, ct);

--- a/Gallery.Api/Services/XApiService.cs
+++ b/Gallery.Api/Services/XApiService.cs
@@ -531,7 +531,9 @@ namespace Gallery.Api.Services
             activity.definition.name = new LanguageMap();
             activity.definition.name.Add("en-US", activityData["name"]);
             activity.definition.description = new LanguageMap();
-            activity.definition.description.Add("en-US", activityData["description"]);
+            if (!string.IsNullOrEmpty(activityData["description"])) {
+                activity.definition.description.Add("en-US", activityData["description"]);
+            }
 
             var context = new Context();
             context.platform = _xApiContext.platform;
@@ -573,7 +575,9 @@ namespace Gallery.Api.Services
                 parent.definition.name = new LanguageMap();
                 parent.definition.name.Add("en-US", parentData["name"]);
                 parent.definition.description = new LanguageMap();
-                parent.definition.description.Add("en-US", parentData["description"]);
+                if (!string.IsNullOrEmpty(parentData["description"])) {
+                    parent.definition.description.Add("en-US", parentData["description"]);
+                }
                 parent.definition.type = new Uri(parentData["activityType"]);
                 if (parentData.ContainsKey("moreInfo")) {
                     parent.definition.moreInfo = new Uri(_xApiOptions.UiUrl + parentData["moreInfo"]);
@@ -589,7 +593,9 @@ namespace Gallery.Api.Services
                 other.definition.name = new LanguageMap();
                 other.definition.name.Add("en-US", otherData["name"]);
                 other.definition.description = new LanguageMap();
-                other.definition.description.Add("en-US", otherData["description"]);
+                if (!string.IsNullOrEmpty(otherData["description"])) {
+                    other.definition.description.Add("en-US", otherData["description"]);
+                }
                 other.definition.type = new Uri(otherData["activityType"]);
                 if (otherData.ContainsKey("moreInfo")) {
                     other.definition.moreInfo = new Uri(_xApiOptions.UiUrl + otherData["moreInfo"]);
@@ -610,7 +616,9 @@ namespace Gallery.Api.Services
                         grouping.definition.name = new LanguageMap();
                         grouping.definition.name.Add("en-US", groupingItem["name"]);
                         grouping.definition.description = new LanguageMap();
-                        grouping.definition.description.Add("en-US", groupingItem["description"]);
+                        if (!string.IsNullOrEmpty(groupingItem["description"])) {
+                            grouping.definition.description.Add("en-US", groupingItem["description"]);
+                        }
                         grouping.definition.type = new Uri(groupingItem["activityType"]);
                         if (groupingItem.ContainsKey("moreInfo") && !string.IsNullOrEmpty(groupingItem["moreInfo"])) {
                             grouping.definition.moreInfo = new Uri(_xApiOptions.UiUrl + groupingItem["moreInfo"]);
@@ -627,7 +635,9 @@ namespace Gallery.Api.Services
                 category.definition.name = new LanguageMap();
                 category.definition.name.Add("en-US", categoryData["name"]);
                 category.definition.description = new LanguageMap();
-                category.definition.description.Add("en-US", categoryData["description"]);
+                if (!string.IsNullOrEmpty(categoryData["description"])) {
+                    category.definition.description.Add("en-US", categoryData["description"]);
+                }
                 category.definition.type = new Uri(categoryData["activityType"]);
                 if (categoryData.ContainsKey("moreInfo")) {
                     category.definition.moreInfo = new Uri(_xApiOptions.UiUrl + categoryData["moreInfo"]);

--- a/Gallery.Api/Services/XApiService.cs
+++ b/Gallery.Api/Services/XApiService.cs
@@ -145,8 +145,8 @@ namespace Gallery.Api.Services
             // Move grouping entry
             var moveGrouping = new Dictionary<String,String>();
             moveGrouping.Add("id", article.Move.ToString());
-            moveGrouping.Add("name", article.Name);
-            moveGrouping.Add("description", article.Summary);
+            moveGrouping.Add("name", $"Move {article.Move}");
+            moveGrouping.Add("description", "");
             moveGrouping.Add("type", "move");
             moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
             moveGrouping.Add("moreInfo", "");
@@ -156,7 +156,7 @@ namespace Gallery.Api.Services
             var injectGrouping = new Dictionary<String,String>();
             injectGrouping.Add("id", article.Inject.ToString());
             injectGrouping.Add("name", $"Inject {article.Inject}");
-            injectGrouping.Add("description", $"Article inject: {article.Inject}. Current exhibit inject: {exhibit.CurrentInject}");
+            injectGrouping.Add("description", "");
             injectGrouping.Add("type", "inject");
             injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
             injectGrouping.Add("moreInfo", "");
@@ -213,8 +213,8 @@ namespace Gallery.Api.Services
             // Move grouping entry
             var moveGrouping = new Dictionary<String,String>();
             moveGrouping.Add("id", article.Move.ToString());
-            moveGrouping.Add("name", article.Name);
-            moveGrouping.Add("description", article.Summary);
+            moveGrouping.Add("name", $"Move {article.Move}");
+            moveGrouping.Add("description", "");
             moveGrouping.Add("type", "move");
             moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
             moveGrouping.Add("moreInfo", "");
@@ -224,7 +224,7 @@ namespace Gallery.Api.Services
             var injectGrouping = new Dictionary<String,String>();
             injectGrouping.Add("id", article.Inject.ToString());
             injectGrouping.Add("name", $"Inject {article.Inject}");
-            injectGrouping.Add("description", $"Article inject: {article.Inject}. Current exhibit inject: {exhibit.CurrentInject}");
+            injectGrouping.Add("description", "");
             injectGrouping.Add("type", "inject");
             injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
             injectGrouping.Add("moreInfo", "");
@@ -311,8 +311,8 @@ namespace Gallery.Api.Services
             {
                 var moveGrouping = new Dictionary<String,String>();
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
-                moveGrouping.Add("name", "Current Move");
-                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
+                moveGrouping.Add("description", "");
                 moveGrouping.Add("type", "move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
@@ -321,7 +321,7 @@ namespace Gallery.Api.Services
                 var injectGrouping = new Dictionary<String,String>();
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
-                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("description", "");
                 injectGrouping.Add("type", "inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
@@ -366,8 +366,8 @@ namespace Gallery.Api.Services
             {
                 var moveGrouping = new Dictionary<String,String>();
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
-                moveGrouping.Add("name", "Current Move");
-                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
+                moveGrouping.Add("description", "");
                 moveGrouping.Add("type", "move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
@@ -376,7 +376,7 @@ namespace Gallery.Api.Services
                 var injectGrouping = new Dictionary<String,String>();
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
-                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("description", "");
                 injectGrouping.Add("type", "inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
@@ -419,8 +419,8 @@ namespace Gallery.Api.Services
             {
                 var moveGrouping = new Dictionary<String,String>();
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
-                moveGrouping.Add("name", "Current Move");
-                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
+                moveGrouping.Add("description", "");
                 moveGrouping.Add("type", "move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
@@ -429,7 +429,7 @@ namespace Gallery.Api.Services
                 var injectGrouping = new Dictionary<String,String>();
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
-                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("description", "");
                 injectGrouping.Add("type", "inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");
@@ -473,8 +473,8 @@ namespace Gallery.Api.Services
             {
                 var moveGrouping = new Dictionary<String,String>();
                 moveGrouping.Add("id", exhibit.CurrentMove.ToString());
-                moveGrouping.Add("name", "Current Move");
-                moveGrouping.Add("description", $"Current exhibit move: {exhibit.CurrentMove}");
+                moveGrouping.Add("name", $"Move {exhibit.CurrentMove}");
+                moveGrouping.Add("description", "");
                 moveGrouping.Add("type", "move");
                 moveGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/collection-simple");
                 moveGrouping.Add("moreInfo", "");
@@ -483,7 +483,7 @@ namespace Gallery.Api.Services
                 var injectGrouping = new Dictionary<String,String>();
                 injectGrouping.Add("id", exhibit.CurrentInject.ToString());
                 injectGrouping.Add("name", $"Inject {exhibit.CurrentInject}");
-                injectGrouping.Add("description", $"Current exhibit inject: {exhibit.CurrentInject}");
+                injectGrouping.Add("description", "");
                 injectGrouping.Add("type", "inject");
                 injectGrouping.Add("activityType", "http://id.tincanapi.com/activitytype/step");
                 injectGrouping.Add("moreInfo", "");


### PR DESCRIPTION
  Summary         

  - Use article name and summary instead of generic "Move N" labels in xAPI move grouping context, aligning with the MSEL terminology standardization effort
  - Change move activity type from step to collection-simple to better reflect that moves are collections of injects, not individual steps
  - Add move and inject grouping context to exhibit-level xAPI statements (wall clock started/stopped, exhibit changed/opened) so they include the current move/inject position
  - Guard against empty description fields when building xAPI statements to prevent errors when articles lack summaries

  Test plan

  - Trigger article-level xAPI events (article posted, article opened) and verify the move grouping uses the article's name/summary instead of "Move N"
  - Verify move activity type is collection-simple in xAPI statements
  - Trigger exhibit-level events (wall clock start/stop, exhibit change/open) and verify move/inject grouping is present when CurrentMove/CurrentInject >= 0
  - Trigger xAPI events with articles that have empty summaries and verify no errors