### PR TITLE
Map database constraint violations to 4xx status codes

### DIFF
--- a/Gallery.Api/Infrastructure/Exceptions/BadRequestException.cs
+++ b/Gallery.Api/Infrastructure/Exceptions/BadRequestException.cs
@@ -1,0 +1,26 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Net;
+
+namespace Gallery.Api.Infrastructure.Exceptions
+{
+    public class BadRequestException : Exception, IApiException
+    {
+        public BadRequestException()
+            : base("Bad Request")
+        {
+        }
+
+        public BadRequestException(string message)
+            : base(message)
+        {
+        }
+
+        public HttpStatusCode GetStatusCode()
+        {
+            return HttpStatusCode.BadRequest;
+        }
+    }
+}

--- a/Gallery.Api/Infrastructure/Exceptions/ConflictException.cs
+++ b/Gallery.Api/Infrastructure/Exceptions/ConflictException.cs
@@ -1,0 +1,26 @@
+// Copyright 2022 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Net;
+
+namespace Gallery.Api.Infrastructure.Exceptions
+{
+    public class ConflictException : Exception, IApiException
+    {
+        public ConflictException()
+            : base("Conflict")
+        {
+        }
+
+        public ConflictException(string message)
+            : base(message)
+        {
+        }
+
+        public HttpStatusCode GetStatusCode()
+        {
+            return HttpStatusCode.Conflict;
+        }
+    }
+}

--- a/Gallery.Api/Infrastructure/Exceptions/Middleware/ExceptionMiddleware.cs
+++ b/Gallery.Api/Infrastructure/Exceptions/Middleware/ExceptionMiddleware.cs
@@ -122,13 +122,13 @@ namespace Gallery.Api.Infrastructure.Exceptions.Middleware
             return pgEx.SqlState switch
             {
                 "23505" => // unique_violation
-                    new InvalidOperationException("A record with this identifier already exists."),
+                    new ConflictException("A record with this identifier already exists."),
 
                 "23503" => // foreign_key_violation
-                    new InvalidOperationException("Referenced entity does not exist. Please verify all referenced entities exist."),
+                    new BadRequestException("Referenced entity does not exist. Please verify all referenced entities exist."),
 
                 "23514" => // check_violation
-                    new InvalidOperationException("Data validation failed."),
+                    new BadRequestException("Data validation failed."),
 
                 _ => new InvalidOperationException("A database error occurred.")
             };
@@ -148,10 +148,10 @@ namespace Gallery.Api.Infrastructure.Exceptions.Middleware
             return sqlEx.Number switch
             {
                 2601 or 2627 => // unique constraint violation
-                    new InvalidOperationException("A record with this identifier already exists."),
+                    new ConflictException("A record with this identifier already exists."),
 
                 547 => // foreign key violation
-                    new InvalidOperationException("Referenced entity does not exist. Please verify all referenced entities exist."),
+                    new BadRequestException("Referenced entity does not exist. Please verify all referenced entities exist."),
 
                 _ => new InvalidOperationException("A database error occurred.")
             };


### PR DESCRIPTION
## The problem

Every database constraint violation is reported as **HTTP 500**, so no API client can distinguish "you sent a bad request" from "the server is broken."

`ExceptionMiddleware.TransformPostgresException` already classifies the SQLSTATE correctly and builds a clean, user-safe message for each case:

```cs
"23505" => new InvalidOperationException("A record with this identifier already exists."),
"23503" => new InvalidOperationException("Referenced entity does not exist. ..."),
"23514" => new InvalidOperationException("Data validation failed."),
```

…but returns a plain `InvalidOperationException`, which does not implement `IApiException`. `GetStatusCodeFromException` only consults `IApiException`, so all three fall through to the `InternalServerError` default. **The classification work is done and then discarded.**

## How to reproduce

`POST /api/teamarticles` twice with the same article/team pair:

```
POST teamarticles -> 500 {"title":"A record with this identifier already exists.","status":500,
 "detail":"System.InvalidOperationException: A record with this identifier already exists."}
```

The body is correct and actionable; only the status code is wrong.

## The fix

Add `ConflictException` (409) and `BadRequestException` (400) alongside the existing `IApiException` types and use them in both transforms:

- unique violations (`23505`, `2601`, `2627`) now return **409**
- foreign-key and check violations (`23503`, `23514`, `547`) now return **400**

Message text is unchanged, so nothing that string-matches a response body breaks. The same change covers SQL Server via `TransformSqlServerException`.

## Note for reviewers

**This is the foundation of the stack.** The two exception types added here are thrown by two later pull requests in this stack, which will not compile without it. Merge bottom-up.

## Verification

Builds clean. End-to-end coverage asserts a real `409` on a duplicate insert (see the card-delete pull request later in this stack); previously a test had to string-match a 500 body to detect a conflict.
