### PR TITLE
Return 400 instead of 500 for invalid collection/exhibit JSON uploads

### DIFF
--- a/Gallery.Api/Services/CollectionService.cs
+++ b/Gallery.Api/Services/CollectionService.cs
@@ -248,7 +248,18 @@ namespace Gallery.Api.Services
             {
                 ReferenceHandler = ReferenceHandler.Preserve
             };
-            var collectionFileObject = JsonSerializer.Deserialize<CollectionFileFormat>(collectionJson, options);
+            CollectionFileFormat collectionFileObject;
+            try
+            {
+                collectionFileObject = JsonSerializer.Deserialize<CollectionFileFormat>(collectionJson, options);
+            }
+            catch (JsonException)
+            {
+                throw new BadRequestException("The uploaded file is not valid JSON.");
+            }
+            if (collectionFileObject == null || collectionFileObject.Collection == null)
+                throw new BadRequestException("The uploaded file is not a valid collection file.");
+
             // make a copy and add it to the database
             var collectionEntity = await privateCollectionCopyAsync(collectionFileObject.Collection, collectionFileObject.Cards, collectionFileObject.Articles, ct);
 

--- a/Gallery.Api/Services/ExhibitService.cs
+++ b/Gallery.Api/Services/ExhibitService.cs
@@ -395,7 +395,18 @@ namespace Gallery.Api.Services
             {
                 ReferenceHandler = ReferenceHandler.Preserve
             };
-            var exhibitFileObject = JsonSerializer.Deserialize<ExhibitFileFormat>(exhibitJson, options);
+            ExhibitFileFormat exhibitFileObject;
+            try
+            {
+                exhibitFileObject = JsonSerializer.Deserialize<ExhibitFileFormat>(exhibitJson, options);
+            }
+            catch (JsonException)
+            {
+                throw new BadRequestException("The uploaded file is not valid JSON.");
+            }
+            if (exhibitFileObject == null || exhibitFileObject.Exhibit == null || exhibitFileObject.Collection == null)
+                throw new BadRequestException("The uploaded file is not a valid exhibit file.");
+
             // make a copy and add it to the database
             var exhibitEntity = await privateExhibitCopyAsync(exhibitFileObject, true, ct);
 


### PR DESCRIPTION
## The problem

`UploadJsonAsync` deserializes the uploaded file with no error handling. `JsonException` does not implement `IApiException`, so a malformed upload becomes a **500** with the raw parser message as its title. Well-formed JSON that simply isn't a collection or exhibit file (`{}`, `[]`) deserializes to a null graph and then `NullReferenceException`s into a 500 as well.

A malformed client upload is a client error, not a server fault.

## How to reproduce

`POST /api/collections/json` with a non-JSON body, then with a truncated one:

```
HTTP 500 {"title":"'this is not json at all\n' is an invalid JSON literal. ...","status":500}
HTTP 500 {"title":"Expected depth to be zero at the end of the JSON payload. ...","status":500}
```

Then post a body of `{}` — a 500 from a null dereference rather than a rejection.

## The fix

Wrap the deserialize in both `CollectionService` and `ExhibitService` and throw `BadRequestException` ("The uploaded file is not valid JSON."), and guard the null / missing-root cases explicitly ("The uploaded file is not a valid collection file.").

## Known gap, deliberately not addressed here

The multipart field name is `ToUpload`, not `file` (`ViewModels/FileForm.cs`). Posting the part as `file` leaves the form field null and still produces a `NullReferenceException` → 500. Arguably a missing file part should also be a 400. Left out to keep this change to a single defect.

## Verification

Builds clean. End-to-end coverage asserts the `400` and the exact title for the non-JSON, malformed, and exhibit cases.
