### PR TITLE
Fix an EF tracking leak that breaks import of downloaded collections

### DIFF
--- a/Gallery.Api/Services/CollectionService.cs
+++ b/Gallery.Api/Services/CollectionService.cs
@@ -155,6 +155,7 @@ namespace Gallery.Api.Services
             collectionEntity.DateModified = collectionEntity.DateCreated;
             collectionEntity.ModifiedBy = collectionEntity.CreatedBy;
             collectionEntity.Name = collectionEntity.Name + " - " + username;
+            collectionEntity.Memberships = null;
             await _context.Collections.AddAsync(collectionEntity, ct);
             // copy cards
             var newCardIds = new Dictionary<Guid, Guid>();
@@ -200,6 +201,7 @@ namespace Gallery.Api.Services
         public async Task<Tuple<MemoryStream, string>> DownloadJsonAsync(Guid collectionId, CancellationToken ct)
         {
             var collection = await _context.Collections
+                .AsNoTracking()
                 .SingleOrDefaultAsync(sm => sm.Id == collectionId, ct);
             if (collection == null)
             {


### PR DESCRIPTION
## The problem

Download a collection as JSON, upload that same file, and get a **500** — intermittently.

```
UP#0 status=500 {"title":"The instance of entity type 'UserEntity' cannot be tracked because
 another instance with the same key value for {'Id'} is already being tracked. ...","status":500}
```

Measured at **6 failures out of 12** through the API, roughly 1-in-3 through the UI. Once a *particular* downloaded file is bad it fails 8/8 — **the variability is in the download, not the upload.**

`DownloadJsonAsync` loads the Collection row *tracked* — no `AsNoTracking()`, unlike the sibling Cards/Articles queries directly below it and unlike the identical query in `ExhibitService`. Authorization has already run on the same scoped `DbContext` and loaded the user's `CollectionMembershipEntity` rows (`UserClaimsService.cs:272`), so EF's identity map populates the tracked entity's `Memberships` navigation **even though the query never included it**. `ReferenceHandler.Preserve` then serializes that graph — nested `UserEntity` included — into the export. On import, `privateCollectionCopyAsync` re-`Add`s it while EF already tracks an entity with the same key, and `SaveChangesAsync` throws.

**Why it's intermittent:** claims are cached for 60 seconds (`CacheExpirationSeconds`). A cache **miss** loads the membership rows and the export embeds them; a **hit** does not.

## How to reproduce

Three consecutive downloads of the same collection:

```
DL#0 bytes=7308 hasMemberships=true hasUser=true  hasUserId=true    <- always 500s on upload
DL#1 bytes=377  hasMemberships=true hasUser=false hasUserId=false   <- uploads fine
DL#2 bytes=377  hasMemberships=true hasUser=false hasUserId=false
```

Proven causal in both directions: with a fresh token the export embeds one membership row and 3/3 uploads return 500; with a warm token it embeds none and the upload returns 200. Injecting a real membership row into a clean export reproduces the 500 deterministically.

## The fix

Add `AsNoTracking()` to the Collections query in `DownloadJsonAsync`, matching `ExhibitService`'s identical export query — which is exactly why the exhibit round-trip works and the collection one does not.

Also null `collectionEntity.Memberships` in `privateCollectionCopyAsync` before `AddAsync`, alongside the existing defensive nulling of `cardEntity.Collection`, `articleEntity.Collection`, and `articleEntity.Card`, **so a file already exported with the bad graph can still be imported.**

Fixing the download half also makes exports deterministic, which matters independently: before this, a downloaded collection might not be re-importable depending on cache timing.

## Verification

Builds clean. End-to-end coverage exercises the full download-then-upload round-trip; the upload half was previously skipped pending this fix and the two halves are now a single test.
