### PR TITLE
Fix the ArticleEntity.Exhibit navigation typed as CardEntity

### DIFF
--- a/Gallery.Api.Data/Models/Article.cs
+++ b/Gallery.Api.Data/Models/Article.cs
@@ -20,7 +20,7 @@ namespace Gallery.Api.Data.Models
         public Guid CollectionId { get; set; }
         public CollectionEntity Collection { get; set; }
         public Guid? ExhibitId { get; set; }
-        public CardEntity Exhibit { get; set; }
+        public ExhibitEntity Exhibit { get; set; }
         public Guid? CardId { get; set; }
         public CardEntity Card { get; set; }
         public int Move { get; set; }

--- a/Gallery.Api.Migrations.PostgreSQL/Migrations/GalleryDbContextModelSnapshot.cs
+++ b/Gallery.Api.Migrations.PostgreSQL/Migrations/GalleryDbContextModelSnapshot.cs
@@ -1045,7 +1045,7 @@ namespace Gallery.Api.Migrations.PostgreSQL.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Gallery.Api.Data.Models.CardEntity", "Exhibit")
+                    b.HasOne("Gallery.Api.Data.Models.ExhibitEntity", "Exhibit")
                         .WithMany()
                         .HasForeignKey("ExhibitId");
 


### PR DESCRIPTION
## The problem

```cs
public Guid? ExhibitId { get; set; }
public CardEntity Exhibit { get; set; }     // <-- should be ExhibitEntity
public Guid? CardId { get; set; }
public CardEntity Card { get; set; }
```

Copy-paste from the `Card` navigation two lines below. EF Core maps `Exhibit` as a **second relationship to `cards`** using `exhibit_id` as the foreign key, so the C# model disagrees with the real schema: migration `20230328212012_article-exhibitId` already created `FK_articles_exhibits_exhibit_id` pointing at `exhibits`, and that constraint is correct in the database.

Latent — it has caused no observed failure, but it would bite anything doing `Include(a => a.Exhibit)`.

## How to reproduce

No runtime reproduction; this is a static model defect. It was confirmed by regenerating the migration — see below.

## The fix

Retype the navigation to `ExhibitEntity`.

No inverse collection is added on `ExhibitEntity`: none of the other correct foreign-key relationships onto `ArticleEntity` (`Card`, `Collection`) declare one, and nothing in the codebase enumerates an exhibit's articles through a navigation.

## Why only the model snapshot is committed, and why there is no migration to run

`dotnet ef migrations add` against the fixed model produced only a drop of a phantom `FK_articles_cards_exhibit_id` — never actually present in the database, an artifact of the wrong model's naming — followed by re-adding `FK_articles_exhibits_exhibit_id` identical to the existing constraint.

A **net no-op**, so that generated migration was discarded. Only the regenerated `GalleryDbContextModelSnapshot.cs` is committed, so the snapshot stops recording the wrong relationship. **No migration needs to be applied.**

## Verification

Builds clean. No end-to-end coverage added — no test navigates this relationship.
