### PR TITLE
Stop sending duplicate card events to the same user group

### DIFF
--- a/Gallery.Api/Infrastructure/EventHandlers/CardHandler.cs
+++ b/Gallery.Api/Infrastructure/EventHandlers/CardHandler.cs
@@ -49,9 +49,15 @@ namespace Gallery.Api.Infrastructure.EventHandlers
             var teamIdList = _db.Teams
                 .Where(t => t.ExhibitId != null && exhibitIdList.Contains((Guid)t.ExhibitId))
                 .Select(t => t.Id);
+            // A user belongs to one team per exhibit, so a user on teams in several
+            // exhibits of this collection appears once per exhibit. Without Distinct
+            // the same user group is sent the same card event several times, and each
+            // copy re-upserts the card and makes every Wall/Archive subscriber
+            // recompute. Every recipient still receives the event, exactly once.
             var userIdList = await _db.TeamUsers
                 .Where(tu => teamIdList.Contains(tu.TeamId))
                 .Select(tu => tu.UserId)
+                .Distinct()
                 .ToListAsync();
             foreach (var userId in userIdList)
             {


### PR DESCRIPTION
## The problem

`CardHandler.GetGroups` collects recipients by walking every exhibit of the card's collection, then every team of those exhibits, then every `TeamUser` of those teams. A user who is on a team in **more than one exhibit of the collection** is therefore returned once per exhibit, and `HandleCreateOrUpdate` sends the card event to that user's group once per duplicate.

Each copy re-upserts the same card into the client's store and makes every Wall and Archive subscriber recompute.

## How to reproduce

Create one collection with two exhibits and put the same user on a team in each. Create or edit a card in that collection and capture the websocket frames — the card event arrives twice for that user.

## The fix

Add `Distinct()` to the `TeamUsers` projection. The set of recipient groups is unchanged; only the repeats are removed, so every user still receives the event, now exactly once.

## Why the group addressing is deliberately left alone

Narrowing these sends to an exhibit group looks like the better fix and is not. `MainHub.Join` adds a connection to the **userId group only**. Exhibit-id groups are joined solely through `SwitchTeam`/`GetTeamIdList`, and the client invokes `switchTeam` only on a reconnect, once a team id is already set.

Addressing an exhibit group would therefore target a group **no connection is a member of** and deliver the events to nobody. Exhibit scoping is done client-side instead — see the corresponding UI pull request.

`TeamCardHandler.GetGroups` is already limited to the `TeamUsers` of the one team, and `UserArticleHandler` sends to the single owning user, so neither over-sends and both are unchanged.

## Verification

Builds clean. Covered indirectly by the client-side exhibit-scoping test, which captures these frames.
